### PR TITLE
 Add ability to set api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To-Do:
 
 CHANGELOG:
 0.0.3 - Add /contact_info/ and /contact_info/{contact_id} routes
+
 0.0.4 - Add ability to set api endpoint (it needs for user in russia because localbitcoins.com is blocked). Usage:
 ```
 var lbc = new LBCClient(api_key, api_secret, {

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ To-Do:
 
 CHANGELOG:
 0.0.3 - Add /contact_info/ and /contact_info/{contact_id} routes
+0.0.4 - Add ability to set api endpoint (it needs for user in russia because localbitcoins.com is blocked). Usage:
+```
+var lbc = new LBCClient(api_key, api_secret, {
+    apiUrl: 'https://localbitcoins.net/api'
+});
+```
 
 Credit:
 

--- a/localbitcoins.js
+++ b/localbitcoins.js
@@ -3,15 +3,14 @@ var crypto		= require('crypto');
 var querystring	= require('querystring');
 
 
-function LBCClient(key, secret, otp) {
+function LBCClient(key, secret, opt = {}) {
 	var nonce = new Date() * 1000;
 	var self = this;
 
 	var config = {
-		url: 'https://localbitcoins.com/api',
+		url: opt.apiUrl || 'https://localbitcoins.com/api',
 		key: key,
 		secret: secret,
-		otp: otp,
 		timeoutMS: 5000
 	};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localbitcoins-api",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "LocalBitcoins API wrapper for NodeJS",
   "keywords": [
     "localbitcoins",


### PR DESCRIPTION
In Russia we have localbitcoins.com blocked so we should have a way to change the endpoint to localbitcoins.net.
Otherwise we get {"code":"CERT_HAS_EXPIRED"}